### PR TITLE
Update docker hub URL from vectorized to redpandadata

### DIFF
--- a/03-monitoring-and-alert/docker-compose.yml
+++ b/03-monitoring-and-alert/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8025:8025
   redpanda0:
-    image: docker.redpanda.com/redpandadata/redpanda:latest
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
     container_name: redpanda-0
     command:
     - redpanda
@@ -36,7 +36,7 @@ services:
     - 9644:9644
     - 28082:28082
   console:
-    image: docker.redpanda.com/redpandadata/console:latest
+    image: docker.redpanda.com/redpandadata/console:v2.7.2
     restart: on-failure
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"

--- a/03-monitoring-and-alert/docker-compose.yml
+++ b/03-monitoring-and-alert/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     ports:
       - 8025:8025
   redpanda0:
-    # NOTE: Please use the latest version here!
-    image: docker.redpanda.com/vectorized/redpanda:latest
+    image: docker.redpanda.com/redpandadata/redpanda:latest
     container_name: redpanda-0
     command:
     - redpanda
@@ -37,7 +36,7 @@ services:
     - 9644:9644
     - 28082:28082
   console:
-    image: docker.redpanda.com/vectorized/console:latest
+    image: docker.redpanda.com/redpandadata/console:latest
     restart: on-failure
     entrypoint: /bin/sh
     command: -c "echo \"$$CONSOLE_CONFIG_FILE\" > /tmp/config.yml; /app/console"


### PR DESCRIPTION
This updates the docker hub URL to pull from the redpandadata repo (rather than vectorized).